### PR TITLE
Fix index.d.ts

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,6 +1,9 @@
 declare module "subtitle-utils" {
-  export = Subtitle;
+  import ISubtitle = Subtitle.ISubtitle;
+  export default Subtitle;
+  export { ISubtitle }
 }
+
 
 declare class Subtitle {
   subtitles: Subtitle.ISubtitle[];
@@ -17,7 +20,7 @@ declare class Subtitle {
 }
 
 declare namespace Subtitle {
-  interface ISubtitle {
+  export interface ISubtitle {
     startTime: number;
     endTime: number;
     texts: string[];


### PR DESCRIPTION
Cannot import this library with TypeScript now.

/* import SubtitleUtils from 'subtitle-utils'; */
error TS1192: Module '"subtitle-utils"' has no default export.

/* import * as SubtitleUtils from 'subtitle-utils'; */
TypeError: SubtitleUtils.fromSRT is not a function